### PR TITLE
Changed schema of operational resources report

### DIFF
--- a/src/handlers/high_level_reports_handler.py
+++ b/src/handlers/high_level_reports_handler.py
@@ -143,15 +143,8 @@ class MaestroModelBuilder:
         assert rep.type == ReportType.OPERATIONAL_RESOURCES
         result = []
         for item in data.get('data', ()):
-            rd = {}
-            for region, res in item.pop('resources', {}).items():
-                rd[region] = {'resources': res}
-            item['regions_data'] = rd
+            item['violations_data'] = item.pop('violations', [])
             result.append(item)
-
-            item.pop('resource_types', None)
-            item.pop('description', None)
-            item.pop('severity', None)
         return {
             'tenant_name': rep.tenant,
             'id': data['id'],

--- a/src/handlers/high_level_reports_handler.py
+++ b/src/handlers/high_level_reports_handler.py
@@ -141,16 +141,12 @@ class MaestroModelBuilder:
     @staticmethod
     def _operational_resources_custom(rep: ReportMetrics, data: dict) -> dict:
         assert rep.type == ReportType.OPERATIONAL_RESOURCES
-        result = []
-        for item in data.get('data', ()):
-            item['violations_data'] = item.pop('violations', [])
-            result.append(item)
         return {
             'tenant_name': rep.tenant,
             'id': data['id'],
             'cloud': rep.cloud.value,  # pyright: ignore
             'tenant_metadata': data['metadata'],
-            'data': result,
+            'data': data['data'],
             'externalData': False,
         }
 

--- a/src/lambdas/custodian_metrics_updater/processors/metrics_collector.py
+++ b/src/lambdas/custodian_metrics_updater/processors/metrics_collector.py
@@ -946,7 +946,7 @@ class MetricsCollector:
 
         _LOG.info('Generating project resources reports for all tenant groups')
         ctx.add_reports(
-            self.project_resources(
+            self.project_resources_with_new_schema(
                 ctx=ctx,
                 operational_reports=list(
                     ctx.iter_reports(typ=ReportType.OPERATIONAL_RESOURCES)
@@ -1446,6 +1446,7 @@ class MetricsCollector:
                 {'outdated_tenants': list(outdated_tenants), 'data': data},
             )
 
+    # TODO: rewrite to not rely on operational resources
     def project_resources(
         self,
         ctx: MetricsContext,
@@ -2401,3 +2402,80 @@ class MetricsCollector:
             self._platforms_cache.clear()
             self._rulesets_cache.clear()
         return {}
+
+    # NOTE: This function is just temporary solution and very inefficient
+    # TODO: rewrite previous project_resources function without operational report
+    def project_resources_with_new_schema(
+        self,
+        ctx: MetricsContext,
+        operational_reports: list[tuple[ReportMetrics, dict]],
+        report_type: ReportType,
+    ) -> ReportsGen:
+        assert all(
+            r[0].type is ReportType.OPERATIONAL_RESOURCES
+            for r in operational_reports
+        )
+
+        # they are totally the same as operational compliance
+        start = report_type.start(ctx.now)
+        end = report_type.end(ctx.now)
+        dn_to_reports = {}
+        for item in operational_reports:
+            tenant = cast(Tenant, self._get_tenant(item[0].tenant))
+            dn_to_reports.setdefault(
+                tenant.display_name_to_lower.lower(), []
+            ).append(item)
+
+        for dn, reports in dn_to_reports.items():
+            data = self.base_cloud_payload_dict()
+            tenants = set()
+            for item in reports:
+                tenant = cast(Tenant, self._get_tenant(item[0].tenant))
+                tenants.add(tenant.name)
+
+                policies_dict = {}
+                for policy in item[1]['metadata'].rules.violated:
+                    policies_dict[policy.id] = {
+                        'description': policy.description,
+                        'severity': policy.severity.value,
+                    }
+                policies_data = {}
+                for resource in item[1]['data']:
+                    for policy in resource['violations']:
+                        if policy['policy'] in policies_data:
+                            region = policies_data[policy['policy']]['regions_data']
+                            if resource['region'] not in region:
+                                region[resource['region']] = {
+                                    'total_violated_resources': 1
+                                }
+                            else:
+                                region[resource['region']]['total_violated_resources'] += 1
+                        else:
+                            policies_data[policy['policy']] = {
+                                'policy': policy['policy'],
+                                'description': policies_dict[policy['policy']]['description'],
+                                'severity': policies_dict[policy['policy']]['severity'],
+                                'resource_type': resource['service'],
+                                'regions_data': {
+                                    resource['region']: {'total_violated_resources': 1}
+                                },
+                            }
+                data[tenant_cloud(tenant).value] = {
+                    'account_id': item[1]['id'],
+                    'tenant_name': tenant.name,
+                    'last_scan_date': item[1]['metadata'].last_scan_date,
+                    'activated_regions': item[1]['metadata'].activated_regions,
+                    'data': list(policies_data.values()),
+                }
+
+            yield (
+                self._rms.create(
+                    key=ReportMetrics.build_key_for_project(
+                        report_type, ctx.customer.name, dn
+                    ),
+                    end=end,
+                    start=start,
+                    tenants=tenants,
+                ),
+                {'outdated_tenants': [], 'data': data},
+            )

--- a/src/services/reports.py
+++ b/src/services/reports.py
@@ -365,10 +365,9 @@ class ResourcesReportGenerator(ReportVisitor[Generator[dict, None, None]]):
                     severity = rm2.severity
                 violations.append({
                     'policy': rule,
-                    # NOTE: This attributes could be retrieved from metadata.rules
                     # 'severity': rm2.severity.value,
                     # 'description': rm.get('description') or '',
-                    # 'sre:date': sync_date
+                    'sre:date': sync_date
                 })
 
             res = resource.accept(

--- a/src/services/resources.py
+++ b/src/services/resources.py
@@ -416,13 +416,20 @@ class MaestroReportResourceView(ResourceVisitor[dict]):
         dct['sre:date'] = resource.sync_date
         return dct
 
+_CC_PROVIDERS_LOADED = False
 
 def load_cc_providers():
-    from c7n.resources import load_available
+    global _CC_PROVIDERS_LOADED
 
-    _LOG.info('Going to load all available Cloud Custodian providers')
-    load_available(resources=True)
-    _LOG.info('Providers were loaded')
+    if not _CC_PROVIDERS_LOADED:
+        from c7n.resources import load_available
+
+        _LOG.info('Going to load all available Cloud Custodian providers')
+        loaded = load_available(resources=True)
+        _CC_PROVIDERS_LOADED = True
+        _LOG.info('Loaded providers: ' + ', '.join(loaded))
+    else:
+        _LOG.info('Cloud Custodian providers were already loaded')
 
 
 def prepare_resource_type(rt: str, cloud: Cloud) -> str:

--- a/tests/data/expected/metrics/aws_operational_resources.json
+++ b/tests/data/expected/metrics/aws_operational_resources.json
@@ -19,7 +19,6 @@
     "finished_scans": 2,
     "succeeded_scans": 1,
     "last_scan_date": "2025-07-21T00:07:52.074854Z",
-    "last_scan_date": "2025-07-21T00:19:52.315331Z",
     "activated_regions": [
       "eu-north-1",
       "eu-west-1",
@@ -174,7 +173,8 @@
       },
       "violations": [
         {
-          "policy": "ecc-aws-070-unused_ec2_security_groups"
+          "policy": "ecc-aws-070-unused_ec2_security_groups",
+          "sre:date": 1729253757.393474
         }
       ]
     },
@@ -190,7 +190,8 @@
       },
       "violations": [
         {
-          "policy": "ecc-aws-070-unused_ec2_security_groups"
+          "policy": "ecc-aws-070-unused_ec2_security_groups",
+          "sre:date": 1729253757.393474
         }
       ]
     },
@@ -206,7 +207,8 @@
       },
       "violations": [
         {
-          "policy": "ecc-aws-070-unused_ec2_security_groups"
+          "policy": "ecc-aws-070-unused_ec2_security_groups",
+          "sre:date": 1729253757.393474
         }
       ]
     },
@@ -222,7 +224,8 @@
       },
       "violations": [
         {
-          "policy": "ecc-aws-374-cloudtrail_logs_data_events"
+          "policy": "ecc-aws-374-cloudtrail_logs_data_events",
+          "sre:date": 1729253780.092237
         }
       ]
     },
@@ -238,7 +241,8 @@
       },
       "violations": [
         {
-          "policy": "ecc-aws-221-sns_kms_encryption_enabled"
+          "policy": "ecc-aws-221-sns_kms_encryption_enabled",
+          "sre:date": 1729253769.274071
         }
       ]
     },
@@ -254,7 +258,8 @@
       },
       "violations": [
         {
-          "policy": "ecc-aws-221-sns_kms_encryption_enabled"
+          "policy": "ecc-aws-221-sns_kms_encryption_enabled",
+          "sre:date": 1729253769.274071
         }
       ]
     },
@@ -270,7 +275,8 @@
       },
       "violations": [
         {
-          "policy": "ecc-aws-221-sns_kms_encryption_enabled"
+          "policy": "ecc-aws-221-sns_kms_encryption_enabled",
+          "sre:date": 1729253769.274071
         }
       ]
     },
@@ -286,10 +292,12 @@
       },
       "violations": [
         {
-          "policy": "ecc-aws-112-s3_bucket_versioning_mfa_delete_enabled"
+          "policy": "ecc-aws-112-s3_bucket_versioning_mfa_delete_enabled",
+          "sre:date": 1729253612.904913
         },
         {
-          "policy": "ecc-aws-516-s3_event_notifications_enabled"
+          "policy": "ecc-aws-516-s3_event_notifications_enabled",
+          "sre:date": 1729253632.1969962
         }
       ]
     },
@@ -305,7 +313,8 @@
       },
       "violations": [
         {
-          "policy": "ecc-aws-112-s3_bucket_versioning_mfa_delete_enabled"
+          "policy": "ecc-aws-112-s3_bucket_versioning_mfa_delete_enabled",
+          "sre:date": 1729253612.904913
         }
       ]
     },
@@ -321,10 +330,12 @@
       },
       "violations": [
         {
-          "policy": "ecc-aws-112-s3_bucket_versioning_mfa_delete_enabled"
+          "policy": "ecc-aws-112-s3_bucket_versioning_mfa_delete_enabled",
+          "sre:date": 1729253612.904913
         },
         {
-          "policy": "ecc-aws-516-s3_event_notifications_enabled"
+          "policy": "ecc-aws-516-s3_event_notifications_enabled",
+          "sre:date": 1729253632.1969962
         }
       ]
     },
@@ -340,10 +351,12 @@
       },
       "violations": [
         {
-          "policy": "ecc-aws-112-s3_bucket_versioning_mfa_delete_enabled"
+          "policy": "ecc-aws-112-s3_bucket_versioning_mfa_delete_enabled",
+          "sre:date": 1729253612.904913
         },
         {
-          "policy": "ecc-aws-516-s3_event_notifications_enabled"
+          "policy": "ecc-aws-516-s3_event_notifications_enabled",
+          "sre:date": 1729253632.1969962
         }
       ]
     },
@@ -359,7 +372,8 @@
       },
       "violations": [
         {
-          "policy": "ecc-aws-112-s3_bucket_versioning_mfa_delete_enabled"
+          "policy": "ecc-aws-112-s3_bucket_versioning_mfa_delete_enabled",
+          "sre:date": 1729253612.904913
         }
       ]
     },
@@ -375,7 +389,8 @@
       },
       "violations": [
         {
-          "policy": "ecc-aws-112-s3_bucket_versioning_mfa_delete_enabled"
+          "policy": "ecc-aws-112-s3_bucket_versioning_mfa_delete_enabled",
+          "sre:date": 1729253612.904913
         }
       ]
     },
@@ -391,7 +406,8 @@
       },
       "violations": [
         {
-          "policy": "ecc-aws-499-iam_group_has_users_check"
+          "policy": "ecc-aws-499-iam_group_has_users_check",
+          "sre:date": 1729253695.934546
         }
       ]
     },
@@ -407,7 +423,8 @@
       },
       "violations": [
         {
-          "policy": "ecc-aws-499-iam_group_has_users_check"
+          "policy": "ecc-aws-499-iam_group_has_users_check",
+          "sre:date": 1729253695.934546
         }
       ]
     },
@@ -423,7 +440,8 @@
       },
       "violations": [
         {
-          "policy": "ecc-aws-499-iam_group_has_users_check"
+          "policy": "ecc-aws-499-iam_group_has_users_check",
+          "sre:date": 1729253695.934546
         }
       ]
     },
@@ -439,7 +457,8 @@
       },
       "violations": [
         {
-          "policy": "ecc-aws-516-s3_event_notifications_enabled"
+          "policy": "ecc-aws-516-s3_event_notifications_enabled",
+          "sre:date": 1729253632.1969962
         }
       ]
     },
@@ -455,7 +474,8 @@
       },
       "violations": [
         {
-          "policy": "ecc-aws-575-ebs_volumes_attached_to_stopped_ec2_instances"
+          "policy": "ecc-aws-575-ebs_volumes_attached_to_stopped_ec2_instances",
+          "sre:date": 1729253990.192673
         }
       ]
     },
@@ -471,7 +491,8 @@
       },
       "violations": [
         {
-          "policy": "ecc-aws-575-ebs_volumes_attached_to_stopped_ec2_instances"
+          "policy": "ecc-aws-575-ebs_volumes_attached_to_stopped_ec2_instances",
+          "sre:date": 1729253990.192673
         }
       ]
     },
@@ -487,7 +508,8 @@
       },
       "violations": [
         {
-          "policy": "ecc-aws-490-ec2_token_hop_limit_check"
+          "policy": "ecc-aws-490-ec2_token_hop_limit_check",
+          "sre:date": 1729253946.722402
         }
       ]
     },
@@ -503,7 +525,8 @@
       },
       "violations": [
         {
-          "policy": "ecc-aws-490-ec2_token_hop_limit_check"
+          "policy": "ecc-aws-490-ec2_token_hop_limit_check",
+          "sre:date": 1729253946.722402
         }
       ]
     },
@@ -519,7 +542,8 @@
       },
       "violations": [
         {
-          "policy": "ecc-aws-229-ecr_repository_kms_encryption_enabled"
+          "policy": "ecc-aws-229-ecr_repository_kms_encryption_enabled",
+          "sre:date": 1729253920.7997608
         }
       ]
     },
@@ -535,7 +559,8 @@
       },
       "violations": [
         {
-          "policy": "ecc-aws-229-ecr_repository_kms_encryption_enabled"
+          "policy": "ecc-aws-229-ecr_repository_kms_encryption_enabled",
+          "sre:date": 1729253920.7997608
         }
       ]
     }

--- a/tests/data/expected/metrics/aws_operational_resources.json
+++ b/tests/data/expected/metrics/aws_operational_resources.json
@@ -11,14 +11,14 @@
         "per": "DAY",
         "description": "Testing license",
         "valid_until": "2100-02-01T15:24:26.175778Z",
-        "valid_from": "2025-07-18T08:56:49.203236Z"
+        "valid_from": "2025-07-21T12:07:51.164456Z"
       }
     ],
     "is_automatic_scans_enabled": true,
     "in_progress_scans": 0,
     "finished_scans": 2,
     "succeeded_scans": 1,
-    "last_scan_date": "2025-07-18T00:56:49.991441Z",
+    "last_scan_date": "2025-07-21T00:07:52.074854Z",
     "activated_regions": [
       "eu-north-1",
       "eu-west-3",
@@ -212,258 +212,381 @@
   },
   "data": [
     {
-      "policy": "ecc-aws-070-unused_ec2_security_groups",
-      "resource_type": "Security Group",
-      "description": "Description for ecc-aws-070-unused_ec2_security_groups",
+      "region": "eu-central-1",
+      "resource_type": "aws.security-group",
+      "service": "Security Group",
       "severity": "Unknown",
-      "resources": {
-        "eu-central-1": [
-          {
-            "id": "sg-0ae266faddaef17e9",
-            "name": "packer-ssh-access",
-            "arn": "arn:aws:ec2:eu-central-1:123456789012:security-group/sg-0ae266faddaef17e9",
-            "sre:date": 1729253757.393474
-          },
-          {
-            "id": "sg-05209ceeb761317e5",
-            "name": "west-eu",
-            "arn": "arn:aws:ec2:eu-central-1:123456789012:security-group/sg-05209ceeb761317e5",
-            "sre:date": 1729253757.393474
-          },
-          {
-            "id": "sg-09d19538187df66cf",
-            "name": "asia",
-            "arn": "arn:aws:ec2:eu-central-1:123456789012:security-group/sg-09d19538187df66cf",
-            "sre:date": 1729253757.393474
-          }
-        ]
-      }
+      "resource": {
+        "id": "sg-0ae266faddaef17e9",
+        "name": "packer-ssh-access",
+        "arn": "arn:aws:ec2:eu-central-1:123456789012:security-group/sg-0ae266faddaef17e9"
+      },
+      "violations": [
+        {
+          "policy": "ecc-aws-070-unused_ec2_security_groups"
+        }
+      ]
     },
     {
-      "policy": "ecc-aws-374-cloudtrail_logs_data_events",
-      "resource_type": "Cloudtrail",
-      "description": "Description for ecc-aws-374-cloudtrail_logs_data_events",
+      "region": "eu-central-1",
+      "resource_type": "aws.security-group",
+      "service": "Security Group",
       "severity": "Unknown",
-      "resources": {
-        "global": [
-          {
-            "id": "arn:aws:cloudtrail:eu-central-1:111111111111:trail/testing-org",
-            "name": "testing-org",
-            "arn": "arn:aws:cloudtrail:eu-central-1:111111111111:trail/testing-org",
-            "sre:date": 1729253780.092237
-          }
-        ]
-      }
+      "resource": {
+        "id": "sg-05209ceeb761317e5",
+        "name": "west-eu",
+        "arn": "arn:aws:ec2:eu-central-1:123456789012:security-group/sg-05209ceeb761317e5"
+      },
+      "violations": [
+        {
+          "policy": "ecc-aws-070-unused_ec2_security_groups"
+        }
+      ]
     },
     {
-      "policy": "ecc-aws-221-sns_kms_encryption_enabled",
-      "resource_type": "Sns",
-      "description": "Description for ecc-aws-221-sns_kms_encryption_enabled",
+      "region": "eu-central-1",
+      "resource_type": "aws.security-group",
+      "service": "Security Group",
       "severity": "Unknown",
-      "resources": {
-        "eu-central-1": [
-          {
-            "id": "arn:aws:sns:eu-central-1:123456789012:testing-guard-duty-topic",
-            "name": "9cd23c4a-9970-4adf-97f9-9d74fb5f9673",
-            "arn": "arn:aws:sns:eu-central-1:123456789012:testing-guard-duty-topic",
-            "sre:date": 1729253769.274071
-          },
-          {
-            "id": "arn:aws:sns:eu-central-1:123456789012:m3-inspector-topic",
-            "name": "9cd23c4a-9970-4adf-97f9-9d74fb5f9673",
-            "arn": "arn:aws:sns:eu-central-1:123456789012:m3-inspector-topic",
-            "sre:date": 1729253769.274071
-          },
-          {
-            "id": "arn:aws:sns:eu-central-1:123456789012:dead",
-            "name": "9cd23c4a-9970-4adf-97f9-9d74fb5f9673",
-            "arn": "arn:aws:sns:eu-central-1:123456789012:dead",
-            "sre:date": 1729253769.274071
-          }
-        ]
-      }
+      "resource": {
+        "id": "sg-09d19538187df66cf",
+        "name": "asia",
+        "arn": "arn:aws:ec2:eu-central-1:123456789012:security-group/sg-09d19538187df66cf"
+      },
+      "violations": [
+        {
+          "policy": "ecc-aws-070-unused_ec2_security_groups"
+        }
+      ]
     },
     {
-      "policy": "ecc-aws-112-s3_bucket_versioning_mfa_delete_enabled",
-      "resource_type": "S3",
-      "description": "Description for ecc-aws-112-s3_bucket_versioning_mfa_delete_enabled",
+      "region": "global",
+      "resource_type": "aws.cloudtrail",
+      "service": "Cloudtrail",
       "severity": "Unknown",
-      "resources": {
-        "eu-west-1": [
-          {
-            "id": "appcomposer-4bzknnwy0n3wuuhd-eu-west-1",
-            "name": "appcomposer-4bzknnwy0n3wuuhd-eu-west-1",
-            "arn": "arn:aws:s3:::appcomposer-4bzknnwy0n3wuuhd-eu-west-1",
-            "sre:date": 1729253612.904913
-          },
-          {
-            "id": "example-rulesets-dev",
-            "name": "example-rulesets-dev",
-            "arn": "arn:aws:s3:::example-rulesets-dev",
-            "sre:date": 1729253612.904913
-          },
-          {
-            "id": "example-reports-dev",
-            "name": "example-reports-dev",
-            "arn": "arn:aws:s3:::example-reports-dev",
-            "sre:date": 1729253612.904913
-          }
-        ],
-        "eu-central-1": [
-          {
-            "id": "example-artifacts",
-            "name": "example-artifacts",
-            "arn": "arn:aws:s3:::example-artifacts",
-            "sre:date": 1729253612.904913
-          }
-        ],
-        "eu-west-3": [
-          {
-            "id": "example-meta-storage-eu-west-3-par",
-            "name": "example-meta-storage-eu-west-3-par",
-            "arn": "arn:aws:s3:::example-meta-storage-eu-west-3-par",
-            "sre:date": 1729253612.904913
-          }
-        ],
-        "eu-north-1": [
-          {
-            "id": "macro-delivery",
-            "name": "macro-delivery",
-            "arn": "arn:aws:s3:::macro-delivery",
-            "sre:date": 1729253612.904913
-          }
-        ]
-      }
+      "resource": {
+        "id": "arn:aws:cloudtrail:eu-central-1:111111111111:trail/testing-org",
+        "name": "testing-org",
+        "arn": "arn:aws:cloudtrail:eu-central-1:111111111111:trail/testing-org"
+      },
+      "violations": [
+        {
+          "policy": "ecc-aws-374-cloudtrail_logs_data_events"
+        }
+      ]
     },
     {
-      "policy": "ecc-aws-499-iam_group_has_users_check",
-      "resource_type": "Iam Group",
-      "description": "Description for ecc-aws-499-iam_group_has_users_check",
+      "region": "eu-central-1",
+      "resource_type": "aws.sns",
+      "service": "Sns",
       "severity": "Unknown",
-      "resources": {
-        "global": [
-          {
-            "id": "example-dev-extended-group",
-            "name": "example-dev-extended-group",
-            "arn": "arn:aws:iam::123456789012:group/example-dev-extended-group",
-            "sre:date": 1729253695.934546
-          },
-          {
-            "id": "DeployGroupWithoutIAM",
-            "name": "DeployGroupWithoutIAM",
-            "arn": "arn:aws:iam::123456789012:group/DeployGroupWithoutIAM",
-            "sre:date": 1729253695.934546
-          },
-          {
-            "id": "example-dev-group",
-            "name": "example-dev-group",
-            "arn": "arn:aws:iam::123456789012:group/example-dev-group",
-            "sre:date": 1729253695.934546
-          }
-        ]
-      }
+      "resource": {
+        "id": "arn:aws:sns:eu-central-1:123456789012:testing-guard-duty-topic",
+        "name": "9cd23c4a-9970-4adf-97f9-9d74fb5f9673",
+        "arn": "arn:aws:sns:eu-central-1:123456789012:testing-guard-duty-topic"
+      },
+      "violations": [
+        {
+          "policy": "ecc-aws-221-sns_kms_encryption_enabled"
+        }
+      ]
     },
     {
-      "policy": "ecc-aws-516-s3_event_notifications_enabled",
-      "resource_type": "S3",
-      "description": "Description for ecc-aws-516-s3_event_notifications_enabled",
+      "region": "eu-central-1",
+      "resource_type": "aws.sns",
+      "service": "Sns",
       "severity": "Unknown",
-      "resources": {
-        "eu-west-1": [
-          {
-            "id": "appcomposer-4bzknnwy0n3wuuhd-eu-west-1",
-            "name": "appcomposer-4bzknnwy0n3wuuhd-eu-west-1",
-            "arn": "arn:aws:s3:::appcomposer-4bzknnwy0n3wuuhd-eu-west-1",
-            "sre:date": 1729253632.1969962
-          },
-          {
-            "id": "example-reports-dev",
-            "name": "example-reports-dev",
-            "arn": "arn:aws:s3:::example-reports-dev",
-            "sre:date": 1729253632.1969962
-          },
-          {
-            "id": "example-meta-storage-eu-west-1-tmp",
-            "name": "example-meta-storage-eu-west-1-tmp",
-            "arn": "arn:aws:s3:::example-meta-storage-eu-west-1-tmp",
-            "sre:date": 1729253632.1969962
-          }
-        ],
-        "eu-central-1": [
-          {
-            "id": "example-artifacts",
-            "name": "example-artifacts",
-            "arn": "arn:aws:s3:::example-artifacts",
-            "sre:date": 1729253632.1969962
-          }
-        ]
-      }
+      "resource": {
+        "id": "arn:aws:sns:eu-central-1:123456789012:m3-inspector-topic",
+        "name": "9cd23c4a-9970-4adf-97f9-9d74fb5f9673",
+        "arn": "arn:aws:sns:eu-central-1:123456789012:m3-inspector-topic"
+      },
+      "violations": [
+        {
+          "policy": "ecc-aws-221-sns_kms_encryption_enabled"
+        }
+      ]
     },
     {
-      "policy": "ecc-aws-575-ebs_volumes_attached_to_stopped_ec2_instances",
-      "resource_type": "Ebs",
-      "description": "Description for ecc-aws-575-ebs_volumes_attached_to_stopped_ec2_instances",
+      "region": "eu-central-1",
+      "resource_type": "aws.sns",
+      "service": "Sns",
       "severity": "Unknown",
-      "resources": {
-        "eu-west-1": [
-          {
-            "id": "vol-060f342d89d8bb757",
-            "name": "vol-060f342d89d8bb757",
-            "arn": "arn:aws:ec2:eu-west-1:123456789012:volume/vol-060f342d89d8bb757",
-            "sre:date": 1729253990.192673
-          },
-          {
-            "id": "vol-080f1194e8b86e0a7",
-            "name": "vol-080f1194e8b86e0a7",
-            "arn": "arn:aws:ec2:eu-west-1:123456789012:volume/vol-080f1194e8b86e0a7",
-            "sre:date": 1729253990.192673
-          }
-        ]
-      }
+      "resource": {
+        "id": "arn:aws:sns:eu-central-1:123456789012:dead",
+        "name": "9cd23c4a-9970-4adf-97f9-9d74fb5f9673",
+        "arn": "arn:aws:sns:eu-central-1:123456789012:dead"
+      },
+      "violations": [
+        {
+          "policy": "ecc-aws-221-sns_kms_encryption_enabled"
+        }
+      ]
     },
     {
-      "policy": "ecc-aws-490-ec2_token_hop_limit_check",
-      "resource_type": "Ec2",
-      "description": "Description for ecc-aws-490-ec2_token_hop_limit_check",
+      "region": "eu-west-1",
+      "resource_type": "aws.s3",
+      "service": "S3",
       "severity": "Unknown",
-      "resources": {
-        "eu-west-1": [
-          {
-            "id": "i-0580697d712fb5b56",
-            "name": "9cd23c4a-9970-4adf-97f9-9d74fb5f9673",
-            "arn": "arn:aws:ec2:eu-west-1:123456789012:instance/i-0580697d712fb5b56",
-            "sre:date": 1729253946.722402
-          },
-          {
-            "id": "i-0771a4eb028bda937",
-            "name": "9cd23c4a-9970-4adf-97f9-9d74fb5f9673",
-            "arn": "arn:aws:ec2:eu-west-1:123456789012:instance/i-0771a4eb028bda937",
-            "sre:date": 1729253946.722402
-          }
-        ]
-      }
+      "resource": {
+        "id": "appcomposer-4bzknnwy0n3wuuhd-eu-west-1",
+        "name": "appcomposer-4bzknnwy0n3wuuhd-eu-west-1",
+        "arn": "arn:aws:s3:::appcomposer-4bzknnwy0n3wuuhd-eu-west-1"
+      },
+      "violations": [
+        {
+          "policy": "ecc-aws-112-s3_bucket_versioning_mfa_delete_enabled"
+        },
+        {
+          "policy": "ecc-aws-516-s3_event_notifications_enabled"
+        }
+      ]
     },
     {
-      "policy": "ecc-aws-229-ecr_repository_kms_encryption_enabled",
-      "resource_type": "Ecr",
-      "description": "Description for ecc-aws-229-ecr_repository_kms_encryption_enabled",
+      "region": "eu-west-1",
+      "resource_type": "aws.s3",
+      "service": "S3",
       "severity": "Unknown",
-      "resources": {
-        "eu-west-1": [
-          {
-            "id": "example-developer-test",
-            "name": "example-developer-test",
-            "arn": "arn:aws:ecr:eu-west-1:123456789012:repository/example-developer-test",
-            "sre:date": 1729253920.7997608
-          },
-          {
-            "id": "application-dev",
-            "name": "application-dev",
-            "arn": "arn:aws:ecr:eu-west-1:123456789012:repository/application-dev",
-            "sre:date": 1729253920.7997608
-          }
-        ]
-      }
+      "resource": {
+        "id": "example-rulesets-dev",
+        "name": "example-rulesets-dev",
+        "arn": "arn:aws:s3:::example-rulesets-dev"
+      },
+      "violations": [
+        {
+          "policy": "ecc-aws-112-s3_bucket_versioning_mfa_delete_enabled"
+        }
+      ]
+    },
+    {
+      "region": "eu-west-1",
+      "resource_type": "aws.s3",
+      "service": "S3",
+      "severity": "Unknown",
+      "resource": {
+        "id": "example-reports-dev",
+        "name": "example-reports-dev",
+        "arn": "arn:aws:s3:::example-reports-dev"
+      },
+      "violations": [
+        {
+          "policy": "ecc-aws-112-s3_bucket_versioning_mfa_delete_enabled"
+        },
+        {
+          "policy": "ecc-aws-516-s3_event_notifications_enabled"
+        }
+      ]
+    },
+    {
+      "region": "eu-central-1",
+      "resource_type": "aws.s3",
+      "service": "S3",
+      "severity": "Unknown",
+      "resource": {
+        "id": "example-artifacts",
+        "name": "example-artifacts",
+        "arn": "arn:aws:s3:::example-artifacts"
+      },
+      "violations": [
+        {
+          "policy": "ecc-aws-112-s3_bucket_versioning_mfa_delete_enabled"
+        },
+        {
+          "policy": "ecc-aws-516-s3_event_notifications_enabled"
+        }
+      ]
+    },
+    {
+      "region": "eu-west-3",
+      "resource_type": "aws.s3",
+      "service": "S3",
+      "severity": "Unknown",
+      "resource": {
+        "id": "example-meta-storage-eu-west-3-par",
+        "name": "example-meta-storage-eu-west-3-par",
+        "arn": "arn:aws:s3:::example-meta-storage-eu-west-3-par"
+      },
+      "violations": [
+        {
+          "policy": "ecc-aws-112-s3_bucket_versioning_mfa_delete_enabled"
+        }
+      ]
+    },
+    {
+      "region": "eu-north-1",
+      "resource_type": "aws.s3",
+      "service": "S3",
+      "severity": "Unknown",
+      "resource": {
+        "id": "macro-delivery",
+        "name": "macro-delivery",
+        "arn": "arn:aws:s3:::macro-delivery"
+      },
+      "violations": [
+        {
+          "policy": "ecc-aws-112-s3_bucket_versioning_mfa_delete_enabled"
+        }
+      ]
+    },
+    {
+      "region": "global",
+      "resource_type": "aws.iam-group",
+      "service": "Iam Group",
+      "severity": "Unknown",
+      "resource": {
+        "id": "example-dev-extended-group",
+        "name": "example-dev-extended-group",
+        "arn": "arn:aws:iam::123456789012:group/example-dev-extended-group"
+      },
+      "violations": [
+        {
+          "policy": "ecc-aws-499-iam_group_has_users_check"
+        }
+      ]
+    },
+    {
+      "region": "global",
+      "resource_type": "aws.iam-group",
+      "service": "Iam Group",
+      "severity": "Unknown",
+      "resource": {
+        "id": "DeployGroupWithoutIAM",
+        "name": "DeployGroupWithoutIAM",
+        "arn": "arn:aws:iam::123456789012:group/DeployGroupWithoutIAM"
+      },
+      "violations": [
+        {
+          "policy": "ecc-aws-499-iam_group_has_users_check"
+        }
+      ]
+    },
+    {
+      "region": "global",
+      "resource_type": "aws.iam-group",
+      "service": "Iam Group",
+      "severity": "Unknown",
+      "resource": {
+        "id": "example-dev-group",
+        "name": "example-dev-group",
+        "arn": "arn:aws:iam::123456789012:group/example-dev-group"
+      },
+      "violations": [
+        {
+          "policy": "ecc-aws-499-iam_group_has_users_check"
+        }
+      ]
+    },
+    {
+      "region": "eu-west-1",
+      "resource_type": "aws.s3",
+      "service": "S3",
+      "severity": "Unknown",
+      "resource": {
+        "id": "example-meta-storage-eu-west-1-tmp",
+        "name": "example-meta-storage-eu-west-1-tmp",
+        "arn": "arn:aws:s3:::example-meta-storage-eu-west-1-tmp"
+      },
+      "violations": [
+        {
+          "policy": "ecc-aws-516-s3_event_notifications_enabled"
+        }
+      ]
+    },
+    {
+      "region": "eu-west-1",
+      "resource_type": "aws.ebs",
+      "service": "Ebs",
+      "severity": "Unknown",
+      "resource": {
+        "id": "vol-060f342d89d8bb757",
+        "name": "vol-060f342d89d8bb757",
+        "arn": "arn:aws:ec2:eu-west-1:123456789012:volume/vol-060f342d89d8bb757"
+      },
+      "violations": [
+        {
+          "policy": "ecc-aws-575-ebs_volumes_attached_to_stopped_ec2_instances"
+        }
+      ]
+    },
+    {
+      "region": "eu-west-1",
+      "resource_type": "aws.ebs",
+      "service": "Ebs",
+      "severity": "Unknown",
+      "resource": {
+        "id": "vol-080f1194e8b86e0a7",
+        "name": "vol-080f1194e8b86e0a7",
+        "arn": "arn:aws:ec2:eu-west-1:123456789012:volume/vol-080f1194e8b86e0a7"
+      },
+      "violations": [
+        {
+          "policy": "ecc-aws-575-ebs_volumes_attached_to_stopped_ec2_instances"
+        }
+      ]
+    },
+    {
+      "region": "eu-west-1",
+      "resource_type": "aws.ec2",
+      "service": "Ec2",
+      "severity": "Unknown",
+      "resource": {
+        "id": "i-0580697d712fb5b56",
+        "name": "9cd23c4a-9970-4adf-97f9-9d74fb5f9673",
+        "arn": "arn:aws:ec2:eu-west-1:123456789012:instance/i-0580697d712fb5b56"
+      },
+      "violations": [
+        {
+          "policy": "ecc-aws-490-ec2_token_hop_limit_check"
+        }
+      ]
+    },
+    {
+      "region": "eu-west-1",
+      "resource_type": "aws.ec2",
+      "service": "Ec2",
+      "severity": "Unknown",
+      "resource": {
+        "id": "i-0771a4eb028bda937",
+        "name": "9cd23c4a-9970-4adf-97f9-9d74fb5f9673",
+        "arn": "arn:aws:ec2:eu-west-1:123456789012:instance/i-0771a4eb028bda937"
+      },
+      "violations": [
+        {
+          "policy": "ecc-aws-490-ec2_token_hop_limit_check"
+        }
+      ]
+    },
+    {
+      "region": "eu-west-1",
+      "resource_type": "aws.ecr",
+      "service": "Ecr",
+      "severity": "Unknown",
+      "resource": {
+        "id": "example-developer-test",
+        "name": "example-developer-test",
+        "arn": "arn:aws:ecr:eu-west-1:123456789012:repository/example-developer-test"
+      },
+      "violations": [
+        {
+          "policy": "ecc-aws-229-ecr_repository_kms_encryption_enabled"
+        }
+      ]
+    },
+    {
+      "region": "eu-west-1",
+      "resource_type": "aws.ecr",
+      "service": "Ecr",
+      "severity": "Unknown",
+      "resource": {
+        "id": "application-dev",
+        "name": "application-dev",
+        "arn": "arn:aws:ecr:eu-west-1:123456789012:repository/application-dev"
+      },
+      "violations": [
+        {
+          "policy": "ecc-aws-229-ecr_repository_kms_encryption_enabled"
+        }
+      ]
     }
   ],
   "id": "123456789012"

--- a/tests/data/expected/metrics/azure_operational_resources.json
+++ b/tests/data/expected/metrics/azure_operational_resources.json
@@ -11,14 +11,14 @@
         "per": "DAY",
         "description": "Testing license",
         "valid_until": "2100-02-01T15:24:26.175778Z",
-        "valid_from": "2025-07-18T08:56:51.494908Z"
+        "valid_from": "2025-07-21T12:39:26.974694Z"
       }
     ],
     "is_automatic_scans_enabled": true,
     "in_progress_scans": 0,
     "finished_scans": 2,
     "succeeded_scans": 1,
-    "last_scan_date": "2025-07-18T00:56:49.991441Z",
+    "last_scan_date": "2025-07-21T00:39:26.603795Z",
     "activated_regions": [],
     "rules": {
       "total": 10,
@@ -117,79 +117,79 @@
   },
   "data": [
     {
-      "policy": "ecc-azure-310-asb_defender_open_source_rds",
-      "resource_type": "Defender Pricing",
-      "description": "Description for ecc-azure-310-asb_defender_open_source_rds",
+      "region": "global",
+      "resource_type": "azure.defender-pricing",
+      "service": "Defender Pricing",
       "severity": "Unknown",
-      "resources": {
-        "global": [
-          {
-            "id": "/subscriptions/3d615fa8-05c6-47ea-990d-9d162testing/providers/Microsoft.Security/pricings/OpenSourceRelationalDatabases",
-            "name": "OpenSourceRelationalDatabases",
-            "sre:date": 1729502354.6635
-          }
-        ]
-      }
+      "resource": {
+        "id": "/subscriptions/3d615fa8-05c6-47ea-990d-9d162testing/providers/Microsoft.Security/pricings/OpenSourceRelationalDatabases",
+        "name": "OpenSourceRelationalDatabases"
+      },
+      "violations": [
+        {
+          "policy": "ecc-azure-310-asb_defender_open_source_rds"
+        }
+      ]
     },
     {
-      "policy": "ecc-azure-096-cis_sec_defender_azure_sql",
-      "resource_type": "Defender Pricing",
-      "description": "Description for ecc-azure-096-cis_sec_defender_azure_sql",
+      "region": "global",
+      "resource_type": "azure.defender-pricing",
+      "service": "Defender Pricing",
       "severity": "Unknown",
-      "resources": {
-        "global": [
-          {
-            "id": "/subscriptions/3d615fa8-05c6-47ea-990d-9d162testing/providers/Microsoft.Security/pricings/SqlServers",
-            "name": "SqlServers",
-            "sre:date": 1729502334.624495
-          }
-        ]
-      }
+      "resource": {
+        "id": "/subscriptions/3d615fa8-05c6-47ea-990d-9d162testing/providers/Microsoft.Security/pricings/SqlServers",
+        "name": "SqlServers"
+      },
+      "violations": [
+        {
+          "policy": "ecc-azure-096-cis_sec_defender_azure_sql"
+        }
+      ]
     },
     {
-      "policy": "ecc-azure-376-cis_defender_cosmodb",
-      "resource_type": "Defender Pricing",
-      "description": "Description for ecc-azure-376-cis_defender_cosmodb",
+      "region": "global",
+      "resource_type": "azure.defender-pricing",
+      "service": "Defender Pricing",
       "severity": "Unknown",
-      "resources": {
-        "global": [
-          {
-            "id": "/subscriptions/3d615fa8-05c6-47ea-990d-9d162testing/providers/Microsoft.Security/pricings/CosmosDbs",
-            "name": "CosmosDbs",
-            "sre:date": 1729502359.150423
-          }
-        ]
-      }
+      "resource": {
+        "id": "/subscriptions/3d615fa8-05c6-47ea-990d-9d162testing/providers/Microsoft.Security/pricings/CosmosDbs",
+        "name": "CosmosDbs"
+      },
+      "violations": [
+        {
+          "policy": "ecc-azure-376-cis_defender_cosmodb"
+        }
+      ]
     },
     {
-      "policy": "ecc-azure-099-cis_sec_defender_aks",
-      "resource_type": "Defender Pricing",
-      "description": "Description for ecc-azure-099-cis_sec_defender_aks",
+      "region": "global",
+      "resource_type": "azure.defender-pricing",
+      "service": "Defender Pricing",
       "severity": "Unknown",
-      "resources": {
-        "global": [
-          {
-            "id": "/subscriptions/3d615fa8-05c6-47ea-990d-9d162testing/providers/Microsoft.Security/pricings/KubernetesService",
-            "name": "KubernetesService",
-            "sre:date": 1729502334.630253
-          }
-        ]
-      }
+      "resource": {
+        "id": "/subscriptions/3d615fa8-05c6-47ea-990d-9d162testing/providers/Microsoft.Security/pricings/KubernetesService",
+        "name": "KubernetesService"
+      },
+      "violations": [
+        {
+          "policy": "ecc-azure-099-cis_sec_defender_aks"
+        }
+      ]
     },
     {
-      "policy": "ecc-azure-213-asb_lt_defender_dns",
-      "resource_type": "Defender Pricing",
-      "description": "Description for ecc-azure-213-asb_lt_defender_dns",
+      "region": "global",
+      "resource_type": "azure.defender-pricing",
+      "service": "Defender Pricing",
       "severity": "Unknown",
-      "resources": {
-        "global": [
-          {
-            "id": "/subscriptions/3d615fa8-05c6-47ea-990d-9d162testing/providers/Microsoft.Security/pricings/Dns",
-            "name": "Dns",
-            "sre:date": 1729502348.720908
-          }
-        ]
-      }
+      "resource": {
+        "id": "/subscriptions/3d615fa8-05c6-47ea-990d-9d162testing/providers/Microsoft.Security/pricings/Dns",
+        "name": "Dns"
+      },
+      "violations": [
+        {
+          "policy": "ecc-azure-213-asb_lt_defender_dns"
+        }
+      ]
     }
   ],
   "id": "3d615fa8-05c6-47ea-990d-9d162testing"

--- a/tests/data/expected/metrics/azure_operational_resources.json
+++ b/tests/data/expected/metrics/azure_operational_resources.json
@@ -127,7 +127,8 @@
       },
       "violations": [
         {
-          "policy": "ecc-azure-310-asb_defender_open_source_rds"
+          "policy": "ecc-azure-310-asb_defender_open_source_rds",
+          "sre:date": 1729502354.6635
         }
       ]
     },
@@ -142,7 +143,8 @@
       },
       "violations": [
         {
-          "policy": "ecc-azure-096-cis_sec_defender_azure_sql"
+          "policy": "ecc-azure-096-cis_sec_defender_azure_sql",
+          "sre:date": 1729502334.624495
         }
       ]
     },
@@ -157,7 +159,8 @@
       },
       "violations": [
         {
-          "policy": "ecc-azure-376-cis_defender_cosmodb"
+          "policy": "ecc-azure-376-cis_defender_cosmodb",
+          "sre:date": 1729502359.150423
         }
       ]
     },
@@ -172,7 +175,8 @@
       },
       "violations": [
         {
-          "policy": "ecc-azure-099-cis_sec_defender_aks"
+          "policy": "ecc-azure-099-cis_sec_defender_aks",
+          "sre:date": 1729502334.630253
         }
       ]
     },
@@ -187,7 +191,8 @@
       },
       "violations": [
         {
-          "policy": "ecc-azure-213-asb_lt_defender_dns"
+          "policy": "ecc-azure-213-asb_lt_defender_dns",
+          "sre:date": 1729502348.720908
         }
       ]
     }

--- a/tests/data/expected/metrics/google_operational_resources.json
+++ b/tests/data/expected/metrics/google_operational_resources.json
@@ -127,9 +127,18 @@
         "urn": "gcp:compute::testing-project-123:firewall/default-allow-internal"
       },
       "violations": [
-        { "policy": "ecc-gcp-109-prevent_allow_all_ingress" },
-        { "policy": "ecc-gcp-272-firewall_logging_enabled" },
-        { "policy": "ecc-gcp-104-default_firewall_rule_in_use" }
+        {
+          "policy": "ecc-gcp-109-prevent_allow_all_ingress",
+          "sre:date": 1729502743.7096498
+        },
+        {
+          "policy": "ecc-gcp-272-firewall_logging_enabled",
+          "sre:date": 1729502744.540606
+        },
+        {
+          "policy": "ecc-gcp-104-default_firewall_rule_in_use",
+          "sre:date": 1729502743.708413
+        }
       ]
     },
     {
@@ -143,7 +152,10 @@
         "urn": "gcp:compute::testing-project-123:vpc/default"
       },
       "violations": [
-        { "policy": "ecc-gcp-025-no_default_network" }
+        {
+          "policy": "ecc-gcp-025-no_default_network",
+          "sre:date": 1729502743.654542
+        }
       ]
     },
     {
@@ -157,7 +169,10 @@
         "urn": "gcp:compute:europe-west10:testing-project-123:subnet/default"
       },
       "violations": [
-        { "policy": "ecc-gcp-033-vpc_flow_logs_for_every_subnet" }
+        {
+          "policy": "ecc-gcp-033-vpc_flow_logs_for_every_subnet",
+          "sre:date": 1729502743.66139
+        }
       ]
     },
     {
@@ -171,7 +186,10 @@
         "urn": "gcp:compute:northamerica-south1:testing-project-123:subnet/default"
       },
       "violations": [
-        { "policy": "ecc-gcp-033-vpc_flow_logs_for_every_subnet" }
+        {
+          "policy": "ecc-gcp-033-vpc_flow_logs_for_every_subnet",
+          "sre:date": 1729502743.66139
+        }
       ]
     },
     {
@@ -185,7 +203,10 @@
         "urn": "gcp:compute:us-west8:testing-project-123:subnet/default"
       },
       "violations": [
-        { "policy": "ecc-gcp-033-vpc_flow_logs_for_every_subnet" }
+        {
+          "policy": "ecc-gcp-033-vpc_flow_logs_for_every_subnet",
+          "sre:date": 1729502743.66139
+        }
       ]
     },
     {
@@ -199,7 +220,10 @@
         "urn": "gcp:compute:africa-south1:testing-project-123:subnet/default"
       },
       "violations": [
-        { "policy": "ecc-gcp-033-vpc_flow_logs_for_every_subnet" }
+        {
+          "policy": "ecc-gcp-033-vpc_flow_logs_for_every_subnet",
+          "sre:date": 1729502743.66139
+        }
       ]
     },
     {
@@ -213,8 +237,14 @@
         "urn": "gcp:compute::testing-project-123:firewall/default-allow-rdp"
       },
       "violations": [
-        { "policy": "ecc-gcp-272-firewall_logging_enabled" },
-        { "policy": "ecc-gcp-104-default_firewall_rule_in_use" }
+        {
+          "policy": "ecc-gcp-272-firewall_logging_enabled",
+          "sre:date": 1729502744.540606
+        },
+        {
+          "policy": "ecc-gcp-104-default_firewall_rule_in_use",
+          "sre:date": 1729502743.708413
+        }
       ]
     },
     {
@@ -228,8 +258,14 @@
         "urn": "gcp:compute::testing-project-123:firewall/default-allow-ssh"
       },
       "violations": [
-        { "policy": "ecc-gcp-272-firewall_logging_enabled" },
-        { "policy": "ecc-gcp-104-default_firewall_rule_in_use" }
+        {
+          "policy": "ecc-gcp-272-firewall_logging_enabled",
+          "sre:date": 1729502744.540606
+        },
+        {
+          "policy": "ecc-gcp-104-default_firewall_rule_in_use",
+          "sre:date": 1729502743.708413
+        }
       ]
     },
     {
@@ -243,8 +279,14 @@
         "urn": "gcp:compute::testing-project-123:firewall/default-allow-icmp"
       },
       "violations": [
-        { "policy": "ecc-gcp-272-firewall_logging_enabled" },
-        { "policy": "ecc-gcp-104-default_firewall_rule_in_use" }
+        {
+          "policy": "ecc-gcp-272-firewall_logging_enabled",
+          "sre:date": 1729502744.540606
+        },
+        {
+          "policy": "ecc-gcp-104-default_firewall_rule_in_use",
+          "sre:date": 1729502743.708413
+        }
       ]
     }
   ],

--- a/tests/data/expected/metrics/google_operational_resources.json
+++ b/tests/data/expected/metrics/google_operational_resources.json
@@ -11,14 +11,14 @@
         "per": "DAY",
         "description": "Testing license",
         "valid_until": "2100-02-01T15:24:26.175778Z",
-        "valid_from": "2025-07-18T08:56:51.534251Z"
+        "valid_from": "2025-07-21T12:53:07.645104Z"
       }
     ],
     "is_automatic_scans_enabled": true,
     "in_progress_scans": 0,
     "finished_scans": 2,
     "succeeded_scans": 1,
-    "last_scan_date": "2025-07-18T00:56:49.991441Z",
+    "last_scan_date": "2025-07-21T00:53:07.202735Z",
     "activated_regions": [],
     "rules": {
       "total": 10,
@@ -117,144 +117,135 @@
   },
   "data": [
     {
-      "policy": "ecc-gcp-025-no_default_network",
-      "resource_type": "Vpc",
-      "description": "Description for ecc-gcp-025-no_default_network",
+      "region": "global",
+      "resource_type": "gcp.firewall",
+      "service": "Firewall",
       "severity": "Unknown",
-      "resources": {
-        "global": [
-          {
-            "id": "877139587449282054",
-            "name": "default",
-            "urn": "gcp:compute::testing-project-123:vpc/default",
-            "sre:date": 1729502743.654542
-          }
-        ]
-      }
+      "resource": {
+        "id": "3339756659677913058",
+        "name": "default-allow-internal",
+        "urn": "gcp:compute::testing-project-123:firewall/default-allow-internal"
+      },
+      "violations": [
+        { "policy": "ecc-gcp-109-prevent_allow_all_ingress" },
+        { "policy": "ecc-gcp-272-firewall_logging_enabled" },
+        { "policy": "ecc-gcp-104-default_firewall_rule_in_use" }
+      ]
     },
     {
-      "policy": "ecc-gcp-272-firewall_logging_enabled",
-      "resource_type": "Firewall",
-      "description": "Description for ecc-gcp-272-firewall_logging_enabled",
+      "region": "global",
+      "resource_type": "gcp.vpc",
+      "service": "Vpc",
       "severity": "Unknown",
-      "resources": {
-        "global": [
-          {
-            "id": "2342562096469303266",
-            "name": "default-allow-rdp",
-            "urn": "gcp:compute::testing-project-123:firewall/default-allow-rdp",
-            "sre:date": 1729502744.540606
-          },
-          {
-            "id": "2007825320515264482",
-            "name": "default-allow-ssh",
-            "urn": "gcp:compute::testing-project-123:firewall/default-allow-ssh",
-            "sre:date": 1729502744.540606
-          },
-          {
-            "id": "3339756659677913058",
-            "name": "default-allow-internal",
-            "urn": "gcp:compute::testing-project-123:firewall/default-allow-internal",
-            "sre:date": 1729502744.540606
-          },
-          {
-            "id": "1227136820292673506",
-            "name": "default-allow-icmp",
-            "urn": "gcp:compute::testing-project-123:firewall/default-allow-icmp",
-            "sre:date": 1729502744.540606
-          }
-        ]
-      }
+      "resource": {
+        "id": "877139587449282054",
+        "name": "default",
+        "urn": "gcp:compute::testing-project-123:vpc/default"
+      },
+      "violations": [
+        { "policy": "ecc-gcp-025-no_default_network" }
+      ]
     },
     {
-      "policy": "ecc-gcp-109-prevent_allow_all_ingress",
-      "resource_type": "Firewall",
-      "description": "Description for ecc-gcp-109-prevent_allow_all_ingress",
+      "region": "europe-west10",
+      "resource_type": "gcp.subnet",
+      "service": "Subnet",
       "severity": "Unknown",
-      "resources": {
-        "global": [
-          {
-            "id": "3339756659677913058",
-            "name": "default-allow-internal",
-            "urn": "gcp:compute::testing-project-123:firewall/default-allow-internal",
-            "sre:date": 1729502743.7096498
-          }
-        ]
-      }
+      "resource": {
+        "id": "2708525157271002654",
+        "name": "default",
+        "urn": "gcp:compute:europe-west10:testing-project-123:subnet/default"
+      },
+      "violations": [
+        { "policy": "ecc-gcp-033-vpc_flow_logs_for_every_subnet" }
+      ]
     },
     {
-      "policy": "ecc-gcp-104-default_firewall_rule_in_use",
-      "resource_type": "Firewall",
-      "description": "Description for ecc-gcp-104-default_firewall_rule_in_use",
+      "region": "northamerica-south1",
+      "resource_type": "gcp.subnet",
+      "service": "Subnet",
       "severity": "Unknown",
-      "resources": {
-        "global": [
-          {
-            "id": "2342562096469303266",
-            "name": "default-allow-rdp",
-            "urn": "gcp:compute::testing-project-123:firewall/default-allow-rdp",
-            "sre:date": 1729502743.708413
-          },
-          {
-            "id": "2007825320515264482",
-            "name": "default-allow-ssh",
-            "urn": "gcp:compute::testing-project-123:firewall/default-allow-ssh",
-            "sre:date": 1729502743.708413
-          },
-          {
-            "id": "3339756659677913058",
-            "name": "default-allow-internal",
-            "urn": "gcp:compute::testing-project-123:firewall/default-allow-internal",
-            "sre:date": 1729502743.708413
-          },
-          {
-            "id": "1227136820292673506",
-            "name": "default-allow-icmp",
-            "urn": "gcp:compute::testing-project-123:firewall/default-allow-icmp",
-            "sre:date": 1729502743.708413
-          }
-        ]
-      }
+      "resource": {
+        "id": "816596276746100793",
+        "name": "default",
+        "urn": "gcp:compute:northamerica-south1:testing-project-123:subnet/default"
+      },
+      "violations": [
+        { "policy": "ecc-gcp-033-vpc_flow_logs_for_every_subnet" }
+      ]
     },
     {
-      "policy": "ecc-gcp-033-vpc_flow_logs_for_every_subnet",
-      "resource_type": "Subnet",
-      "description": "Description for ecc-gcp-033-vpc_flow_logs_for_every_subnet",
+      "region": "us-west8",
+      "resource_type": "gcp.subnet",
+      "service": "Subnet",
       "severity": "Unknown",
-      "resources": {
-        "europe-west10": [
-          {
-            "id": "2708525157271002654",
-            "name": "default",
-            "urn": "gcp:compute:europe-west10:testing-project-123:subnet/default",
-            "sre:date": 1729502743.66139
-          }
-        ],
-        "africa-south1": [
-          {
-            "id": "80118305852546590",
-            "name": "default",
-            "urn": "gcp:compute:africa-south1:testing-project-123:subnet/default",
-            "sre:date": 1729502743.66139
-          }
-        ],
-        "us-west8": [
-          {
-            "id": "3115367106910640951",
-            "name": "default",
-            "urn": "gcp:compute:us-west8:testing-project-123:subnet/default",
-            "sre:date": 1729502743.66139
-          }
-        ],
-        "northamerica-south1": [
-          {
-            "id": "816596276746100793",
-            "name": "default",
-            "urn": "gcp:compute:northamerica-south1:testing-project-123:subnet/default",
-            "sre:date": 1729502743.66139
-          }
-        ]
-      }
+      "resource": {
+        "id": "3115367106910640951",
+        "name": "default",
+        "urn": "gcp:compute:us-west8:testing-project-123:subnet/default"
+      },
+      "violations": [
+        { "policy": "ecc-gcp-033-vpc_flow_logs_for_every_subnet" }
+      ]
+    },
+    {
+      "region": "africa-south1",
+      "resource_type": "gcp.subnet",
+      "service": "Subnet",
+      "severity": "Unknown",
+      "resource": {
+        "id": "80118305852546590",
+        "name": "default",
+        "urn": "gcp:compute:africa-south1:testing-project-123:subnet/default"
+      },
+      "violations": [
+        { "policy": "ecc-gcp-033-vpc_flow_logs_for_every_subnet" }
+      ]
+    },
+    {
+      "region": "global",
+      "resource_type": "gcp.firewall",
+      "service": "Firewall",
+      "severity": "Unknown",
+      "resource": {
+        "id": "2342562096469303266",
+        "name": "default-allow-rdp",
+        "urn": "gcp:compute::testing-project-123:firewall/default-allow-rdp"
+      },
+      "violations": [
+        { "policy": "ecc-gcp-272-firewall_logging_enabled" },
+        { "policy": "ecc-gcp-104-default_firewall_rule_in_use" }
+      ]
+    },
+    {
+      "region": "global",
+      "resource_type": "gcp.firewall",
+      "service": "Firewall",
+      "severity": "Unknown",
+      "resource": {
+        "id": "2007825320515264482",
+        "name": "default-allow-ssh",
+        "urn": "gcp:compute::testing-project-123:firewall/default-allow-ssh"
+      },
+      "violations": [
+        { "policy": "ecc-gcp-272-firewall_logging_enabled" },
+        { "policy": "ecc-gcp-104-default_firewall_rule_in_use" }
+      ]
+    },
+    {
+      "region": "global",
+      "resource_type": "gcp.firewall",
+      "service": "Firewall",
+      "severity": "Unknown",
+      "resource": {
+        "id": "1227136820292673506",
+        "name": "default-allow-icmp",
+        "urn": "gcp:compute::testing-project-123:firewall/default-allow-icmp"
+      },
+      "violations": [
+        { "policy": "ecc-gcp-272-firewall_logging_enabled" },
+        { "policy": "ecc-gcp-104-default_firewall_rule_in_use" }
+      ]
     }
   ],
   "id": "testing-project-123"

--- a/tests/data/expected/operational/resources_report.json
+++ b/tests/data/expected/operational/resources_report.json
@@ -23,9 +23,10 @@
         "name": "packer-ssh-access",
         "arn": "arn:aws:ec2:eu-central-1:123456789012:security-group/sg-0ae266faddaef17e9"
       },
-      "violations_data": [
+      "violations": [
         {
-          "policy": "ecc-aws-070-unused_ec2_security_groups"
+          "policy": "ecc-aws-070-unused_ec2_security_groups",
+          "sre:date": 1729253757.393474
         }
       ]
     },
@@ -39,9 +40,10 @@
         "name": "west-eu",
         "arn": "arn:aws:ec2:eu-central-1:123456789012:security-group/sg-05209ceeb761317e5"
       },
-      "violations_data": [
+      "violations": [
         {
-          "policy": "ecc-aws-070-unused_ec2_security_groups"
+          "policy": "ecc-aws-070-unused_ec2_security_groups",
+          "sre:date": 1729253757.393474
         }
       ]
     },
@@ -55,9 +57,10 @@
         "name": "asia",
         "arn": "arn:aws:ec2:eu-central-1:123456789012:security-group/sg-09d19538187df66cf"
       },
-      "violations_data": [
+      "violations": [
         {
-          "policy": "ecc-aws-070-unused_ec2_security_groups"
+          "policy": "ecc-aws-070-unused_ec2_security_groups",
+          "sre:date": 1729253757.393474
         }
       ]
     },
@@ -71,9 +74,10 @@
         "name": "testing-org",
         "arn": "arn:aws:cloudtrail:eu-central-1:111111111111:trail/testing-org"
       },
-      "violations_data": [
+      "violations": [
         {
-          "policy": "ecc-aws-374-cloudtrail_logs_data_events"
+          "policy": "ecc-aws-374-cloudtrail_logs_data_events",
+          "sre:date": 1729253780.092237
         }
       ]
     },
@@ -87,9 +91,10 @@
         "name": "9cd23c4a-9970-4adf-97f9-9d74fb5f9673",
         "arn": "arn:aws:sns:eu-central-1:123456789012:testing-guard-duty-topic"
       },
-      "violations_data": [
+      "violations": [
         {
-          "policy": "ecc-aws-221-sns_kms_encryption_enabled"
+          "policy": "ecc-aws-221-sns_kms_encryption_enabled",
+          "sre:date": 1729253769.274071
         }
       ]
     },
@@ -103,9 +108,10 @@
         "name": "9cd23c4a-9970-4adf-97f9-9d74fb5f9673",
         "arn": "arn:aws:sns:eu-central-1:123456789012:m3-inspector-topic"
       },
-      "violations_data": [
+      "violations": [
         {
-          "policy": "ecc-aws-221-sns_kms_encryption_enabled"
+          "policy": "ecc-aws-221-sns_kms_encryption_enabled",
+          "sre:date": 1729253769.274071
         }
       ]
     },
@@ -119,9 +125,10 @@
         "name": "9cd23c4a-9970-4adf-97f9-9d74fb5f9673",
         "arn": "arn:aws:sns:eu-central-1:123456789012:dead"
       },
-      "violations_data": [
+      "violations": [
         {
-          "policy": "ecc-aws-221-sns_kms_encryption_enabled"
+          "policy": "ecc-aws-221-sns_kms_encryption_enabled",
+          "sre:date": 1729253769.274071
         }
       ]
     },
@@ -135,12 +142,14 @@
         "name": "appcomposer-4bzknnwy0n3wuuhd-eu-west-1",
         "arn": "arn:aws:s3:::appcomposer-4bzknnwy0n3wuuhd-eu-west-1"
       },
-      "violations_data": [
+      "violations": [
         {
-          "policy": "ecc-aws-112-s3_bucket_versioning_mfa_delete_enabled"
+          "policy": "ecc-aws-112-s3_bucket_versioning_mfa_delete_enabled",
+          "sre:date": 1729253612.904913
         },
         {
-          "policy": "ecc-aws-516-s3_event_notifications_enabled"
+          "policy": "ecc-aws-516-s3_event_notifications_enabled",
+          "sre:date": 1729253632.1969962
         }
       ]
     },
@@ -154,9 +163,10 @@
         "name": "example-rulesets-dev",
         "arn": "arn:aws:s3:::example-rulesets-dev"
       },
-      "violations_data": [
+      "violations": [
         {
-          "policy": "ecc-aws-112-s3_bucket_versioning_mfa_delete_enabled"
+          "policy": "ecc-aws-112-s3_bucket_versioning_mfa_delete_enabled",
+          "sre:date": 1729253612.904913
         }
       ]
     },
@@ -170,12 +180,14 @@
         "name": "example-reports-dev",
         "arn": "arn:aws:s3:::example-reports-dev"
       },
-      "violations_data": [
+      "violations": [
         {
-          "policy": "ecc-aws-112-s3_bucket_versioning_mfa_delete_enabled"
+          "policy": "ecc-aws-112-s3_bucket_versioning_mfa_delete_enabled",
+          "sre:date": 1729253612.904913
         },
         {
-          "policy": "ecc-aws-516-s3_event_notifications_enabled"
+          "policy": "ecc-aws-516-s3_event_notifications_enabled",
+          "sre:date": 1729253632.1969962
         }
       ]
     },
@@ -189,12 +201,14 @@
         "name": "example-artifacts",
         "arn": "arn:aws:s3:::example-artifacts"
       },
-      "violations_data": [
+      "violations": [
         {
-          "policy": "ecc-aws-112-s3_bucket_versioning_mfa_delete_enabled"
+          "policy": "ecc-aws-112-s3_bucket_versioning_mfa_delete_enabled",
+          "sre:date": 1729253612.904913
         },
         {
-          "policy": "ecc-aws-516-s3_event_notifications_enabled"
+          "policy": "ecc-aws-516-s3_event_notifications_enabled",
+          "sre:date": 1729253632.1969962
         }
       ]
     },
@@ -208,9 +222,10 @@
         "name": "example-meta-storage-eu-west-3-par",
         "arn": "arn:aws:s3:::example-meta-storage-eu-west-3-par"
       },
-      "violations_data": [
+      "violations": [
         {
-          "policy": "ecc-aws-112-s3_bucket_versioning_mfa_delete_enabled"
+          "policy": "ecc-aws-112-s3_bucket_versioning_mfa_delete_enabled",
+          "sre:date": 1729253612.904913
         }
       ]
     },
@@ -224,9 +239,10 @@
         "name": "macro-delivery",
         "arn": "arn:aws:s3:::macro-delivery"
       },
-      "violations_data": [
+      "violations": [
         {
-          "policy": "ecc-aws-112-s3_bucket_versioning_mfa_delete_enabled"
+          "policy": "ecc-aws-112-s3_bucket_versioning_mfa_delete_enabled",
+          "sre:date": 1729253612.904913
         }
       ]
     },
@@ -240,9 +256,10 @@
         "name": "example-dev-extended-group",
         "arn": "arn:aws:iam::123456789012:group/example-dev-extended-group"
       },
-      "violations_data": [
+      "violations": [
         {
-          "policy": "ecc-aws-499-iam_group_has_users_check"
+          "policy": "ecc-aws-499-iam_group_has_users_check",
+          "sre:date": 1729253695.934546
         }
       ]
     },
@@ -256,9 +273,10 @@
         "name": "DeployGroupWithoutIAM",
         "arn": "arn:aws:iam::123456789012:group/DeployGroupWithoutIAM"
       },
-      "violations_data": [
+      "violations": [
         {
-          "policy": "ecc-aws-499-iam_group_has_users_check"
+          "policy": "ecc-aws-499-iam_group_has_users_check",
+          "sre:date": 1729253695.934546
         }
       ]
     },
@@ -272,9 +290,10 @@
         "name": "example-dev-group",
         "arn": "arn:aws:iam::123456789012:group/example-dev-group"
       },
-      "violations_data": [
+      "violations": [
         {
-          "policy": "ecc-aws-499-iam_group_has_users_check"
+          "policy": "ecc-aws-499-iam_group_has_users_check",
+          "sre:date": 1729253695.934546
         }
       ]
     },
@@ -288,9 +307,10 @@
         "name": "example-meta-storage-eu-west-1-tmp",
         "arn": "arn:aws:s3:::example-meta-storage-eu-west-1-tmp"
       },
-      "violations_data": [
+      "violations": [
         {
-          "policy": "ecc-aws-516-s3_event_notifications_enabled"
+          "policy": "ecc-aws-516-s3_event_notifications_enabled",
+          "sre:date": 1729253632.1969962
         }
       ]
     },
@@ -304,9 +324,10 @@
         "name": "vol-060f342d89d8bb757",
         "arn": "arn:aws:ec2:eu-west-1:123456789012:volume/vol-060f342d89d8bb757"
       },
-      "violations_data": [
+      "violations": [
         {
-          "policy": "ecc-aws-575-ebs_volumes_attached_to_stopped_ec2_instances"
+          "policy": "ecc-aws-575-ebs_volumes_attached_to_stopped_ec2_instances",
+          "sre:date": 1729253990.192673
         }
       ]
     },
@@ -320,9 +341,10 @@
         "name": "vol-080f1194e8b86e0a7",
         "arn": "arn:aws:ec2:eu-west-1:123456789012:volume/vol-080f1194e8b86e0a7"
       },
-      "violations_data": [
+      "violations": [
         {
-          "policy": "ecc-aws-575-ebs_volumes_attached_to_stopped_ec2_instances"
+          "policy": "ecc-aws-575-ebs_volumes_attached_to_stopped_ec2_instances",
+          "sre:date": 1729253990.192673
         }
       ]
     },
@@ -336,9 +358,10 @@
         "name": "9cd23c4a-9970-4adf-97f9-9d74fb5f9673",
         "arn": "arn:aws:ec2:eu-west-1:123456789012:instance/i-0580697d712fb5b56"
       },
-      "violations_data": [
+      "violations": [
         {
-          "policy": "ecc-aws-490-ec2_token_hop_limit_check"
+          "policy": "ecc-aws-490-ec2_token_hop_limit_check",
+          "sre:date": 1729253946.722402
         }
       ]
     },
@@ -352,9 +375,10 @@
         "name": "9cd23c4a-9970-4adf-97f9-9d74fb5f9673",
         "arn": "arn:aws:ec2:eu-west-1:123456789012:instance/i-0771a4eb028bda937"
       },
-      "violations_data": [
+      "violations": [
         {
-          "policy": "ecc-aws-490-ec2_token_hop_limit_check"
+          "policy": "ecc-aws-490-ec2_token_hop_limit_check",
+          "sre:date": 1729253946.722402
         }
       ]
     },
@@ -368,9 +392,10 @@
         "name": "example-developer-test",
         "arn": "arn:aws:ecr:eu-west-1:123456789012:repository/example-developer-test"
       },
-      "violations_data": [
+      "violations": [
         {
-          "policy": "ecc-aws-229-ecr_repository_kms_encryption_enabled"
+          "policy": "ecc-aws-229-ecr_repository_kms_encryption_enabled",
+          "sre:date": 1729253920.7997608
         }
       ]
     },
@@ -384,9 +409,10 @@
         "name": "application-dev",
         "arn": "arn:aws:ecr:eu-west-1:123456789012:repository/application-dev"
       },
-      "violations_data": [
+      "violations": [
         {
-          "policy": "ecc-aws-229-ecr_repository_kms_encryption_enabled"
+          "policy": "ecc-aws-229-ecr_repository_kms_encryption_enabled",
+          "sre:date": 1729253920.7997608
         }
       ]
     }

--- a/tests/data/expected/operational/resources_report.json
+++ b/tests/data/expected/operational/resources_report.json
@@ -7,273 +7,388 @@
     "type": "OPERATIONAL_RESOURCES",
     "description": "All resources for a specific tenant as of date of generation",
     "version": "2.0.0",
-    "created_at": "2025-07-21T09:24:09.421543Z",
-    "to": "2025-07-21T09:24:09.421543Z",
-    "from": "2025-07-20T09:24:09.421543Z"
+    "created_at": "2025-07-21T14:55:20.362360Z",
+    "to": "2025-07-21T14:55:20.362360Z",
+    "from": "2025-07-20T14:55:20.362360Z"
   },
   "externalData": false,
   "data": [
     {
-      "policy": "ecc-aws-070-unused_ec2_security_groups",
-      "resource_type": "Security Group",
-      "regions_data": {
-        "eu-central-1": {
-          "resources": [
-            {
-              "id": "sg-05209ceeb761317e5",
-              "name": "west-eu",
-              "arn": "arn:aws:ec2:eu-central-1:123456789012:security-group/sg-05209ceeb761317e5",
-              "sre:date": 1729253757.393474
-            },
-            {
-              "id": "sg-0ae266faddaef17e9",
-              "name": "packer-ssh-access",
-              "arn": "arn:aws:ec2:eu-central-1:123456789012:security-group/sg-0ae266faddaef17e9",
-              "sre:date": 1729253757.393474
-            },
-            {
-              "id": "sg-09d19538187df66cf",
-              "name": "asia",
-              "arn": "arn:aws:ec2:eu-central-1:123456789012:security-group/sg-09d19538187df66cf",
-              "sre:date": 1729253757.393474
-            }
-          ]
+      "region": "eu-central-1",
+      "resource_type": "aws.security-group",
+      "service": "Security Group",
+      "severity": "Unknown",
+      "resource": {
+        "id": "sg-0ae266faddaef17e9",
+        "name": "packer-ssh-access",
+        "arn": "arn:aws:ec2:eu-central-1:123456789012:security-group/sg-0ae266faddaef17e9"
+      },
+      "violations_data": [
+        {
+          "policy": "ecc-aws-070-unused_ec2_security_groups"
         }
-      }
+      ]
     },
     {
-      "policy": "ecc-aws-374-cloudtrail_logs_data_events",
-      "resource_type": "Cloudtrail",
-      "regions_data": {
-        "global": {
-          "resources": [
-            {
-              "id": "arn:aws:cloudtrail:eu-central-1:111111111111:trail/testing-org",
-              "name": "testing-org",
-              "arn": "arn:aws:cloudtrail:eu-central-1:111111111111:trail/testing-org",
-              "sre:date": 1729253780.092237
-            }
-          ]
+      "region": "eu-central-1",
+      "resource_type": "aws.security-group",
+      "service": "Security Group",
+      "severity": "Unknown",
+      "resource": {
+        "id": "sg-05209ceeb761317e5",
+        "name": "west-eu",
+        "arn": "arn:aws:ec2:eu-central-1:123456789012:security-group/sg-05209ceeb761317e5"
+      },
+      "violations_data": [
+        {
+          "policy": "ecc-aws-070-unused_ec2_security_groups"
         }
-      }
+      ]
     },
     {
-      "policy": "ecc-aws-221-sns_kms_encryption_enabled",
-      "resource_type": "Sns",
-      "regions_data": {
-        "eu-central-1": {
-          "resources": [
-            {
-              "id": "arn:aws:sns:eu-central-1:123456789012:dead",
-              "name": "9cd23c4a-9970-4adf-97f9-9d74fb5f9673",
-              "arn": "arn:aws:sns:eu-central-1:123456789012:dead",
-              "sre:date": 1729253769.274071
-            },
-            {
-              "id": "arn:aws:sns:eu-central-1:123456789012:m3-inspector-topic",
-              "name": "9cd23c4a-9970-4adf-97f9-9d74fb5f9673",
-              "arn": "arn:aws:sns:eu-central-1:123456789012:m3-inspector-topic",
-              "sre:date": 1729253769.274071
-            },
-            {
-              "id": "arn:aws:sns:eu-central-1:123456789012:testing-guard-duty-topic",
-              "name": "9cd23c4a-9970-4adf-97f9-9d74fb5f9673",
-              "arn": "arn:aws:sns:eu-central-1:123456789012:testing-guard-duty-topic",
-              "sre:date": 1729253769.274071
-            }
-          ]
+      "region": "eu-central-1",
+      "resource_type": "aws.security-group",
+      "service": "Security Group",
+      "severity": "Unknown",
+      "resource": {
+        "id": "sg-09d19538187df66cf",
+        "name": "asia",
+        "arn": "arn:aws:ec2:eu-central-1:123456789012:security-group/sg-09d19538187df66cf"
+      },
+      "violations_data": [
+        {
+          "policy": "ecc-aws-070-unused_ec2_security_groups"
         }
-      }
+      ]
     },
     {
-      "policy": "ecc-aws-112-s3_bucket_versioning_mfa_delete_enabled",
-      "resource_type": "S3",
-      "regions_data": {
-        "eu-west-1": {
-          "resources": [
-            {
-              "id": "appcomposer-4bzknnwy0n3wuuhd-eu-west-1",
-              "name": "appcomposer-4bzknnwy0n3wuuhd-eu-west-1",
-              "arn": "arn:aws:s3:::appcomposer-4bzknnwy0n3wuuhd-eu-west-1",
-              "sre:date": 1729253612.904913
-            },
-            {
-              "id": "example-reports-dev",
-              "name": "example-reports-dev",
-              "arn": "arn:aws:s3:::example-reports-dev",
-              "sre:date": 1729253612.904913
-            },
-            {
-              "id": "example-rulesets-dev",
-              "name": "example-rulesets-dev",
-              "arn": "arn:aws:s3:::example-rulesets-dev",
-              "sre:date": 1729253612.904913
-            }
-          ]
+      "region": "global",
+      "resource_type": "aws.cloudtrail",
+      "service": "Cloudtrail",
+      "severity": "Unknown",
+      "resource": {
+        "id": "arn:aws:cloudtrail:eu-central-1:111111111111:trail/testing-org",
+        "name": "testing-org",
+        "arn": "arn:aws:cloudtrail:eu-central-1:111111111111:trail/testing-org"
+      },
+      "violations_data": [
+        {
+          "policy": "ecc-aws-374-cloudtrail_logs_data_events"
+        }
+      ]
+    },
+    {
+      "region": "eu-central-1",
+      "resource_type": "aws.sns",
+      "service": "Sns",
+      "severity": "Unknown",
+      "resource": {
+        "id": "arn:aws:sns:eu-central-1:123456789012:testing-guard-duty-topic",
+        "name": "9cd23c4a-9970-4adf-97f9-9d74fb5f9673",
+        "arn": "arn:aws:sns:eu-central-1:123456789012:testing-guard-duty-topic"
+      },
+      "violations_data": [
+        {
+          "policy": "ecc-aws-221-sns_kms_encryption_enabled"
+        }
+      ]
+    },
+    {
+      "region": "eu-central-1",
+      "resource_type": "aws.sns",
+      "service": "Sns",
+      "severity": "Unknown",
+      "resource": {
+        "id": "arn:aws:sns:eu-central-1:123456789012:m3-inspector-topic",
+        "name": "9cd23c4a-9970-4adf-97f9-9d74fb5f9673",
+        "arn": "arn:aws:sns:eu-central-1:123456789012:m3-inspector-topic"
+      },
+      "violations_data": [
+        {
+          "policy": "ecc-aws-221-sns_kms_encryption_enabled"
+        }
+      ]
+    },
+    {
+      "region": "eu-central-1",
+      "resource_type": "aws.sns",
+      "service": "Sns",
+      "severity": "Unknown",
+      "resource": {
+        "id": "arn:aws:sns:eu-central-1:123456789012:dead",
+        "name": "9cd23c4a-9970-4adf-97f9-9d74fb5f9673",
+        "arn": "arn:aws:sns:eu-central-1:123456789012:dead"
+      },
+      "violations_data": [
+        {
+          "policy": "ecc-aws-221-sns_kms_encryption_enabled"
+        }
+      ]
+    },
+    {
+      "region": "eu-west-1",
+      "resource_type": "aws.s3",
+      "service": "S3",
+      "severity": "Unknown",
+      "resource": {
+        "id": "appcomposer-4bzknnwy0n3wuuhd-eu-west-1",
+        "name": "appcomposer-4bzknnwy0n3wuuhd-eu-west-1",
+        "arn": "arn:aws:s3:::appcomposer-4bzknnwy0n3wuuhd-eu-west-1"
+      },
+      "violations_data": [
+        {
+          "policy": "ecc-aws-112-s3_bucket_versioning_mfa_delete_enabled"
         },
-        "eu-central-1": {
-          "resources": [
-            {
-              "id": "example-artifacts",
-              "name": "example-artifacts",
-              "arn": "arn:aws:s3:::example-artifacts",
-              "sre:date": 1729253612.904913
-            }
-          ]
+        {
+          "policy": "ecc-aws-516-s3_event_notifications_enabled"
+        }
+      ]
+    },
+    {
+      "region": "eu-west-1",
+      "resource_type": "aws.s3",
+      "service": "S3",
+      "severity": "Unknown",
+      "resource": {
+        "id": "example-rulesets-dev",
+        "name": "example-rulesets-dev",
+        "arn": "arn:aws:s3:::example-rulesets-dev"
+      },
+      "violations_data": [
+        {
+          "policy": "ecc-aws-112-s3_bucket_versioning_mfa_delete_enabled"
+        }
+      ]
+    },
+    {
+      "region": "eu-west-1",
+      "resource_type": "aws.s3",
+      "service": "S3",
+      "severity": "Unknown",
+      "resource": {
+        "id": "example-reports-dev",
+        "name": "example-reports-dev",
+        "arn": "arn:aws:s3:::example-reports-dev"
+      },
+      "violations_data": [
+        {
+          "policy": "ecc-aws-112-s3_bucket_versioning_mfa_delete_enabled"
         },
-        "eu-north-1": {
-          "resources": [
-            {
-              "id": "macro-delivery",
-              "name": "macro-delivery",
-              "arn": "arn:aws:s3:::macro-delivery",
-              "sre:date": 1729253612.904913
-            }
-          ]
+        {
+          "policy": "ecc-aws-516-s3_event_notifications_enabled"
+        }
+      ]
+    },
+    {
+      "region": "eu-central-1",
+      "resource_type": "aws.s3",
+      "service": "S3",
+      "severity": "Unknown",
+      "resource": {
+        "id": "example-artifacts",
+        "name": "example-artifacts",
+        "arn": "arn:aws:s3:::example-artifacts"
+      },
+      "violations_data": [
+        {
+          "policy": "ecc-aws-112-s3_bucket_versioning_mfa_delete_enabled"
         },
-        "eu-west-3": {
-          "resources": [
-            {
-              "id": "example-meta-storage-eu-west-3-par",
-              "name": "example-meta-storage-eu-west-3-par",
-              "arn": "arn:aws:s3:::example-meta-storage-eu-west-3-par",
-              "sre:date": 1729253612.904913
-            }
-          ]
+        {
+          "policy": "ecc-aws-516-s3_event_notifications_enabled"
         }
-      }
+      ]
     },
     {
-      "policy": "ecc-aws-499-iam_group_has_users_check",
-      "resource_type": "Iam Group",
-      "regions_data": {
-        "global": {
-          "resources": [
-            {
-              "id": "DeployGroupWithoutIAM",
-              "name": "DeployGroupWithoutIAM",
-              "arn": "arn:aws:iam::123456789012:group/DeployGroupWithoutIAM",
-              "sre:date": 1729253695.934546
-            },
-            {
-              "id": "example-dev-group",
-              "name": "example-dev-group",
-              "arn": "arn:aws:iam::123456789012:group/example-dev-group",
-              "sre:date": 1729253695.934546
-            },
-            {
-              "id": "example-dev-extended-group",
-              "name": "example-dev-extended-group",
-              "arn": "arn:aws:iam::123456789012:group/example-dev-extended-group",
-              "sre:date": 1729253695.934546
-            }
-          ]
+      "region": "eu-west-3",
+      "resource_type": "aws.s3",
+      "service": "S3",
+      "severity": "Unknown",
+      "resource": {
+        "id": "example-meta-storage-eu-west-3-par",
+        "name": "example-meta-storage-eu-west-3-par",
+        "arn": "arn:aws:s3:::example-meta-storage-eu-west-3-par"
+      },
+      "violations_data": [
+        {
+          "policy": "ecc-aws-112-s3_bucket_versioning_mfa_delete_enabled"
         }
-      }
+      ]
     },
     {
-      "policy": "ecc-aws-516-s3_event_notifications_enabled",
-      "resource_type": "S3",
-      "regions_data": {
-        "eu-west-1": {
-          "resources": [
-            {
-              "id": "example-meta-storage-eu-west-1-tmp",
-              "name": "example-meta-storage-eu-west-1-tmp",
-              "arn": "arn:aws:s3:::example-meta-storage-eu-west-1-tmp",
-              "sre:date": 1729253632.1969962
-            },
-            {
-              "id": "appcomposer-4bzknnwy0n3wuuhd-eu-west-1",
-              "name": "appcomposer-4bzknnwy0n3wuuhd-eu-west-1",
-              "arn": "arn:aws:s3:::appcomposer-4bzknnwy0n3wuuhd-eu-west-1",
-              "sre:date": 1729253632.1969962
-            },
-            {
-              "id": "example-reports-dev",
-              "name": "example-reports-dev",
-              "arn": "arn:aws:s3:::example-reports-dev",
-              "sre:date": 1729253632.1969962
-            }
-          ]
-        },
-        "eu-central-1": {
-          "resources": [
-            {
-              "id": "example-artifacts",
-              "name": "example-artifacts",
-              "arn": "arn:aws:s3:::example-artifacts",
-              "sre:date": 1729253632.1969962
-            }
-          ]
+      "region": "eu-north-1",
+      "resource_type": "aws.s3",
+      "service": "S3",
+      "severity": "Unknown",
+      "resource": {
+        "id": "macro-delivery",
+        "name": "macro-delivery",
+        "arn": "arn:aws:s3:::macro-delivery"
+      },
+      "violations_data": [
+        {
+          "policy": "ecc-aws-112-s3_bucket_versioning_mfa_delete_enabled"
         }
-      }
+      ]
     },
     {
-      "policy": "ecc-aws-575-ebs_volumes_attached_to_stopped_ec2_instances",
-      "resource_type": "Ebs",
-      "regions_data": {
-        "eu-west-1": {
-          "resources": [
-            {
-              "id": "vol-080f1194e8b86e0a7",
-              "name": "vol-080f1194e8b86e0a7",
-              "arn": "arn:aws:ec2:eu-west-1:123456789012:volume/vol-080f1194e8b86e0a7",
-              "sre:date": 1729253990.192673
-            },
-            {
-              "id": "vol-060f342d89d8bb757",
-              "name": "vol-060f342d89d8bb757",
-              "arn": "arn:aws:ec2:eu-west-1:123456789012:volume/vol-060f342d89d8bb757",
-              "sre:date": 1729253990.192673
-            }
-          ]
+      "region": "global",
+      "resource_type": "aws.iam-group",
+      "service": "Iam Group",
+      "severity": "Unknown",
+      "resource": {
+        "id": "example-dev-extended-group",
+        "name": "example-dev-extended-group",
+        "arn": "arn:aws:iam::123456789012:group/example-dev-extended-group"
+      },
+      "violations_data": [
+        {
+          "policy": "ecc-aws-499-iam_group_has_users_check"
         }
-      }
+      ]
     },
     {
-      "policy": "ecc-aws-490-ec2_token_hop_limit_check",
-      "resource_type": "Ec2",
-      "regions_data": {
-        "eu-west-1": {
-          "resources": [
-            {
-              "id": "i-0580697d712fb5b56",
-              "name": "9cd23c4a-9970-4adf-97f9-9d74fb5f9673",
-              "arn": "arn:aws:ec2:eu-west-1:123456789012:instance/i-0580697d712fb5b56",
-              "sre:date": 1729253946.722402
-            },
-            {
-              "id": "i-0771a4eb028bda937",
-              "name": "9cd23c4a-9970-4adf-97f9-9d74fb5f9673",
-              "arn": "arn:aws:ec2:eu-west-1:123456789012:instance/i-0771a4eb028bda937",
-              "sre:date": 1729253946.722402
-            }
-          ]
+      "region": "global",
+      "resource_type": "aws.iam-group",
+      "service": "Iam Group",
+      "severity": "Unknown",
+      "resource": {
+        "id": "DeployGroupWithoutIAM",
+        "name": "DeployGroupWithoutIAM",
+        "arn": "arn:aws:iam::123456789012:group/DeployGroupWithoutIAM"
+      },
+      "violations_data": [
+        {
+          "policy": "ecc-aws-499-iam_group_has_users_check"
         }
-      }
+      ]
     },
     {
-      "policy": "ecc-aws-229-ecr_repository_kms_encryption_enabled",
-      "resource_type": "Ecr",
-      "regions_data": {
-        "eu-west-1": {
-          "resources": [
-            {
-              "id": "application-dev",
-              "name": "application-dev",
-              "arn": "arn:aws:ecr:eu-west-1:123456789012:repository/application-dev",
-              "sre:date": 1729253920.7997608
-            },
-            {
-              "id": "example-developer-test",
-              "name": "example-developer-test",
-              "arn": "arn:aws:ecr:eu-west-1:123456789012:repository/example-developer-test",
-              "sre:date": 1729253920.7997608
-            }
-          ]
+      "region": "global",
+      "resource_type": "aws.iam-group",
+      "service": "Iam Group",
+      "severity": "Unknown",
+      "resource": {
+        "id": "example-dev-group",
+        "name": "example-dev-group",
+        "arn": "arn:aws:iam::123456789012:group/example-dev-group"
+      },
+      "violations_data": [
+        {
+          "policy": "ecc-aws-499-iam_group_has_users_check"
         }
-      }
+      ]
+    },
+    {
+      "region": "eu-west-1",
+      "resource_type": "aws.s3",
+      "service": "S3",
+      "severity": "Unknown",
+      "resource": {
+        "id": "example-meta-storage-eu-west-1-tmp",
+        "name": "example-meta-storage-eu-west-1-tmp",
+        "arn": "arn:aws:s3:::example-meta-storage-eu-west-1-tmp"
+      },
+      "violations_data": [
+        {
+          "policy": "ecc-aws-516-s3_event_notifications_enabled"
+        }
+      ]
+    },
+    {
+      "region": "eu-west-1",
+      "resource_type": "aws.ebs",
+      "service": "Ebs",
+      "severity": "Unknown",
+      "resource": {
+        "id": "vol-060f342d89d8bb757",
+        "name": "vol-060f342d89d8bb757",
+        "arn": "arn:aws:ec2:eu-west-1:123456789012:volume/vol-060f342d89d8bb757"
+      },
+      "violations_data": [
+        {
+          "policy": "ecc-aws-575-ebs_volumes_attached_to_stopped_ec2_instances"
+        }
+      ]
+    },
+    {
+      "region": "eu-west-1",
+      "resource_type": "aws.ebs",
+      "service": "Ebs",
+      "severity": "Unknown",
+      "resource": {
+        "id": "vol-080f1194e8b86e0a7",
+        "name": "vol-080f1194e8b86e0a7",
+        "arn": "arn:aws:ec2:eu-west-1:123456789012:volume/vol-080f1194e8b86e0a7"
+      },
+      "violations_data": [
+        {
+          "policy": "ecc-aws-575-ebs_volumes_attached_to_stopped_ec2_instances"
+        }
+      ]
+    },
+    {
+      "region": "eu-west-1",
+      "resource_type": "aws.ec2",
+      "service": "Ec2",
+      "severity": "Unknown",
+      "resource": {
+        "id": "i-0580697d712fb5b56",
+        "name": "9cd23c4a-9970-4adf-97f9-9d74fb5f9673",
+        "arn": "arn:aws:ec2:eu-west-1:123456789012:instance/i-0580697d712fb5b56"
+      },
+      "violations_data": [
+        {
+          "policy": "ecc-aws-490-ec2_token_hop_limit_check"
+        }
+      ]
+    },
+    {
+      "region": "eu-west-1",
+      "resource_type": "aws.ec2",
+      "service": "Ec2",
+      "severity": "Unknown",
+      "resource": {
+        "id": "i-0771a4eb028bda937",
+        "name": "9cd23c4a-9970-4adf-97f9-9d74fb5f9673",
+        "arn": "arn:aws:ec2:eu-west-1:123456789012:instance/i-0771a4eb028bda937"
+      },
+      "violations_data": [
+        {
+          "policy": "ecc-aws-490-ec2_token_hop_limit_check"
+        }
+      ]
+    },
+    {
+      "region": "eu-west-1",
+      "resource_type": "aws.ecr",
+      "service": "Ecr",
+      "severity": "Unknown",
+      "resource": {
+        "id": "example-developer-test",
+        "name": "example-developer-test",
+        "arn": "arn:aws:ecr:eu-west-1:123456789012:repository/example-developer-test"
+      },
+      "violations_data": [
+        {
+          "policy": "ecc-aws-229-ecr_repository_kms_encryption_enabled"
+        }
+      ]
+    },
+    {
+      "region": "eu-west-1",
+      "resource_type": "aws.ecr",
+      "service": "Ecr",
+      "severity": "Unknown",
+      "resource": {
+        "id": "application-dev",
+        "name": "application-dev",
+        "arn": "arn:aws:ecr:eu-west-1:123456789012:repository/application-dev"
+      },
+      "violations_data": [
+        {
+          "policy": "ecc-aws-229-ecr_repository_kms_encryption_enabled"
+        }
+      ]
     }
   ],
   "tenant_name": "AWS-TESTING",
@@ -291,7 +406,7 @@
         "per": "DAY",
         "description": "Testing license",
         "valid_until": "2100-02-01T15:24:26.175778Z",
-        "valid_from": "2025-07-21T09:19:51.511515Z"
+        "valid_from": "2025-07-21T12:07:51.164456Z"
       }
     ],
     "is_automatic_scans_enabled": true,


### PR DESCRIPTION
- Changed `ResourcesReportGenerator` to return report in new schema that is easier to use.
- Wrote temporary function `project_resources_with_new_schema` to work with new schema in operational resources report. 